### PR TITLE
Add export script for distributable zip files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2025-01-28
+
+### Added
+- Export script for creating distributable zip files
+
 ## [1.2.0] - 2025-01-27
 
 ### Added

--- a/DefaultCurrentExpansion.toc
+++ b/DefaultCurrentExpansion.toc
@@ -2,7 +2,7 @@
 ## Title: Default Current Expansion
 ## Notes: Automatically selects "Current Expansion Only" in Auction House and Crafting Orders filters
 ## Author: KidMoxie
-## Version: 1.2.0
+## Version: 1.2.1
 ## X-License: MIT
 ## X-Website: https://github.com/KidMoxie/default-current-expansion
 ## X-Curse-Project-ID: 1409180

--- a/export.sh
+++ b/export.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Export DefaultCurrentExpansion addon as a distributable zip file
+# Usage: ./export.sh [destination]
+# Example: ./export.sh ~/Desktop
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADDON_NAME="DefaultCurrentExpansion"
+
+# Get destination from argument or use current directory
+DEST="${1:-.}"
+DEST="$(cd "$DEST" 2>/dev/null && pwd)" || { echo "Error: Invalid destination '$1'"; exit 1; }
+
+# Extract version from TOC file
+VERSION=$(grep -E "^## Version:" "$SCRIPT_DIR/$ADDON_NAME.toc" | sed 's/## Version: //')
+if [ -z "$VERSION" ]; then
+    echo "Error: Could not extract version from TOC file"
+    exit 1
+fi
+
+ZIP_NAME="$ADDON_NAME.$VERSION.zip"
+TEMP_DIR=$(mktemp -d)
+
+# Create addon directory structure
+mkdir -p "$TEMP_DIR/$ADDON_NAME"
+cp "$SCRIPT_DIR/$ADDON_NAME.lua" "$TEMP_DIR/$ADDON_NAME/"
+cp "$SCRIPT_DIR/$ADDON_NAME.toc" "$TEMP_DIR/$ADDON_NAME/"
+
+# Create zip file
+cd "$TEMP_DIR"
+zip -r "$DEST/$ZIP_NAME" "$ADDON_NAME"
+
+# Cleanup
+rm -rf "$TEMP_DIR"
+
+echo "Created: $DEST/$ZIP_NAME"


### PR DESCRIPTION
## Summary
- Add `export.sh` script for creating distributable zip files
- Extracts version from TOC file automatically
- Creates properly structured zip (DefaultCurrentExpansion/<files>)
- Bump version to 1.2.1

## Usage
```bash
./export.sh ~/Desktop
# Creates: DefaultCurrentExpansion.1.2.1.zip
```

## Test plan
- [ ] Run `./export.sh ~/Desktop` and verify zip is created
- [ ] Extract zip and verify folder structure is correct
- [ ] Verify addon loads correctly from extracted folder