### PR TITLE
Fix taint propagation causing ADDON_ACTION_FORBIDDEN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,13 @@ Global `DCE_L` table created in `Locales/enUS.lua` with all English strings. Non
   - If `preserveFilterChanges` is on and user has manually changed that filter, uses `userFilterOverride[filter]`
   - Otherwise sets the filter to `true`
   - Writes into `AuctionHouseFrame.SearchBar.FilterButton.filters[filterEnum]`
-- Calls `searchBar:UpdateClearFiltersButton()`, then starts a 0.2s ticker (`StartFilterWatcher`) that polls only the actively managed filters for user changes
+- Starts a 0.2s ticker (`StartFilterWatcher`) that polls only the actively managed filters for user changes
+- Note: `UpdateClearFiltersButton()` was intentionally removed to prevent taint propagation (see issue #10)
 - The `SetDisplayMode` hook skips Auctionator's empty-table `SetDisplayMode({})` calls via `next(displayMode) ~= nil`
 
 **Crafting Orders** (`CRAFTINGORDERS_SHOW_CUSTOMER`):
 - 0.1s delay → for each enabled filter (`FILTER_CEO` if `craftingOrders` is on, `FILTER_USABLE` if `usableOnlyCO` is on), writes `true` into the corresponding slot in `ProfessionsCustomerOrdersFrame.BrowseOrders.SearchBar.FilterDropdown.filters`
-- Calls `filterDropdown:ValidateResetState()`
+- Note: `ValidateResetState()` was intentionally removed to prevent taint propagation (see issue #10)
 
 The 0.1s delay exists because Blizzard frames are not fully initialized on the event fire. Do not remove it.
 
@@ -78,7 +79,7 @@ These paths are most likely to break on WoW patches (failures are silent — no 
 1. **AH filter path**: `AuctionHouseFrame.SearchBar.FilterButton.filters`
 2. **CO filter path**: `ProfessionsCustomerOrdersFrame.BrowseOrders.SearchBar.FilterDropdown.filters`
 3. **Enum values**: `Enum.AuctionHouseFilter.CurrentExpansionOnly` and `Enum.AuctionHouseFilter.UsableOnly` — could be renamed or removed (hoisted to `FILTER_CEO`/`FILTER_USABLE` locals with nil guards)
-4. **UI update calls**: `UpdateClearFiltersButton()` and `ValidateResetState()` — internal Blizzard methods, not a stable API
+4. **UI update calls**: `UpdateClearFiltersButton()` and `ValidateResetState()` were removed to prevent taint propagation — calling Blizzard frame methods from addon code taints the frame hierarchy (see issue #10). Do not re-add them.
 5. **SetDisplayMode hook**: If Blizzard renames/removes this method, the hook silently stops (filter still applies on initial open, just not on tab switch)
 
 ## Release Process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Updated all 6 locale files with translated strings for the new feature
 
 ### Fixed
+- ADDON_ACTION_FORBIDDEN error after extended gameplay sessions caused by taint propagation from Blizzard method calls (#10)
 - Filter watcher now tracks subsequent manual toggles correctly within an AH session
 - SetDisplayMode hook no longer duplicates after `/reload`
 - `/dce opt` no longer errors if called before addon is fully loaded

--- a/DefaultCurrentExpansion.lua
+++ b/DefaultCurrentExpansion.lua
@@ -114,7 +114,6 @@ local function ApplyAuctionHouseFilter()
 						ApplyOneFilter(filterButton.filters, FILTER_USABLE)
 					end
 
-					searchBar:UpdateClearFiltersButton()
 					StartFilterWatcher()
 				end
 			end
@@ -159,7 +158,6 @@ local function OnCraftingOrdersShow()
 						if FILTER_USABLE and DefaultCurrentExpansionDB.usableOnlyCO then
 							filterDropdown.filters[FILTER_USABLE] = true
 						end
-						filterDropdown:ValidateResetState()
 					end
 				end
 			end


### PR DESCRIPTION
## Summary

- Remove UpdateClearFiltersButton() and ValidateResetState() calls that executed Blizzard frame methods from addon (tainted) code
- These calls spread taint into the frame hierarchy via SetShown() on child frames, eventually propagating to UseContainerItem after 2-3 hours of gameplay
- Filter values are still written correctly — these calls were cosmetic UI polish (show/hide clear/reset buttons), not functional
- Updated AGENTS.md to document why these calls must not be re-added

## Root Cause Analysis

WoW taint model means all addon code is tainted. When our addon called searchBar:UpdateClearFiltersButton(), it executed Blizzard code (ClearFiltersButton:SetShown(...)) from a tainted context, tainting the frame visibility state. Over extended sessions, this taint accumulated through Blizzard UI layout updates until it reached ContainerFrame, blocking the protected UseContainerItem function.

## Test plan

- [ ] Install addon and play for 2-3+ hours with AH usage — verify no ADDON_ACTION_FORBIDDEN errors when using bag items
- [ ] Open AH — verify Current Expansion Only filter still applies correctly
- [ ] Enable Usable Only — verify it applies correctly
- [ ] Verify filter clear button visual state updates naturally when user interacts with filters

Fixes #10