### PR TITLE
Bump to 1.6.0 for WoW 12.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0] - 2026-04-21
+
+### Changed
+- Interface bumped to 120005 for WoW 12.0.5 compatibility
+
 ## [1.5.0] - 2026-04-04
 
 ### Added

--- a/DefaultCurrentExpansion.toc
+++ b/DefaultCurrentExpansion.toc
@@ -1,8 +1,8 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: Default Current Expansion
 ## Notes: Automatically selects "Current Expansion Only" in Auction House and Crafting Orders filters
 ## Author: KidMoxie
-## Version: 1.5.0
+## Version: 1.6.0
 ## X-License: MIT
 ## X-Website: https://github.com/KidMoxie/default-current-expansion
 ## X-Curse-Project-ID: 1409180

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A World of Warcraft addon that automatically applies filters in the Auction Hous
 - Automatically applies "Current Expansion Only" filter when opening the Auction House and when browsing Crafting Orders
 - Optionally applies "Usable Only" filter for the Auction House and Crafting Orders
 - Each filter has independent per-surface (AH/CO) toggles
-- Compatible with retail WoW 12.0.0+ (Midnight)
+- Compatible with retail WoW 12.0.5 (Midnight)
 
 ## Installation
 
@@ -59,7 +59,7 @@ After installation, simply:
 
 ## Compatibility
 
-- **Current Version:** Retail WoW 12.0.0+ (Midnight)
+- **Current Version:** Retail WoW 12.0.5 (Midnight)
 - **Not compatible with:** Classic WoW, Classic Era, or Cataclysm Classic
 
 ## Contributing


### PR DESCRIPTION
## Summary
- Bumps `Interface` to `120005` and `Version` to `1.6.0` in the TOC for the 12.0.5 release (2026-04-21)
- No code changes — reviewed the [12.0.5 API changes](https://warcraft.wiki.gg/wiki/Patch_12.0.5/API_changes) page; nothing touches our fragile areas (AH `SearchBar.FilterButton.filters`, CO `BrowseOrders.SearchBar.FilterDropdown.filters`, `Enum.AuctionHouseFilter.CurrentExpansionOnly`/`UsableOnly`, `SetDisplayMode` hook, or the Settings canvas API)

## Test plan
- [ ] Load in 12.0.5 retail, confirm no "out of date" warning
- [ ] Open AH Buy tab — "Current Expansion Only" auto-applies
- [ ] Open Crafting Orders (Customer) — filter auto-applies
- [ ] `/dce` opens the options panel; version shows `1.6.0`