### PR TITLE
Fix AH filter path for WoW 12.1.0 (Interface 120100)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Global `DCE_L` table created in `Locales/enUS.lua` with all English strings. Non
 - For each enabled filter (`FILTER_CEO` if `auctionHouse` is on, `FILTER_USABLE` if `usableOnlyAH` is on):
   - If `preserveFilterChanges` is on and user has manually changed that filter, uses `userFilterOverride[filter]`
   - Otherwise sets the filter to `true`
-  - Writes into `AuctionHouseFrame.SearchBar.FilterButton.filters[filterEnum]`
+  - Writes into `g_auctionHouseFilters.filters[filterEnum]` (12.1.0+; Clear Filters replaces that table wholesale, so it is re-resolved on every use via `GetAuctionHouseFilters()` and never cached)
 - Starts a 0.2s ticker (`StartFilterWatcher`) that polls only the actively managed filters for user changes
 - Note: `UpdateClearFiltersButton()` was intentionally removed to prevent taint propagation (see issue #10)
 - The `SetDisplayMode` hook skips Auctionator's empty-table `SetDisplayMode({})` calls via `next(displayMode) ~= nil`
@@ -47,7 +47,7 @@ Registered via `Settings.RegisterCanvasLayoutCategory` (modern Settings API). Us
 ## Constraints
 
 ### Target Version
-- **Retail only** (Interface 120001, Midnight era)
+- **Retail only** (Interface 120100, Midnight era)
 - Not compatible with Classic, Classic Era, or Cataclysm Classic
 - Lua 5.1 (WoW's embedded runtime)
 
@@ -76,10 +76,11 @@ Registered via `Settings.RegisterCanvasLayoutCategory` (modern Settings API). Us
 
 These paths are most likely to break on WoW patches (failures are silent — no error, filter just isn't set):
 
-1. **AH filter path**: `AuctionHouseFrame.SearchBar.FilterButton.filters`
+1. **AH filter path**: `g_auctionHouseFilters.filters` — a saved-variable global owned by Blizzard_AuctionHouseUI (`## SavedVariablesPerCharacter`). Before 12.1.0 this lived at `AuctionHouseFrame.SearchBar.FilterButton.filters`; that field no longer exists. `AuctionHouseFrame.SearchBar` is still used, but only as the Buy-tab gate
 2. **CO filter path**: `ProfessionsCustomerOrdersFrame.BrowseOrders.SearchBar.FilterDropdown.filters`
 3. **Enum values**: `Enum.AuctionHouseFilter.CurrentExpansionOnly` and `Enum.AuctionHouseFilter.UsableOnly` — could be renamed or removed (hoisted to `FILTER_CEO`/`FILTER_USABLE` locals with nil guards)
 4. **UI update calls**: `UpdateClearFiltersButton()` and `ValidateResetState()` were removed to prevent taint propagation — calling Blizzard frame methods from addon code taints the frame hierarchy (see issue #10). Do not re-add them.
+   - Since 12.1.0 the AH filters table is no longer reset on every AH open (`SearchBar:OnShow` used to call `FilterButton:Reset()`, which allocated a fresh untainted table each time). The addon's taint on `g_auctionHouseFilters.filters` now survives the whole session, until the user clicks Clear Filters. Unavoidable — writing that table is the addon's purpose — but it makes #10-style `ADDON_ACTION_FORBIDDEN` reports more likely. Watch for them.
 5. **SetDisplayMode hook**: If Blizzard renames/removes this method, the hook silently stops (filter still applies on initial open, just not on tab switch)
 
 ## Release Process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.7.0] - 2026-08-12
+
+### Fixed
+- Auction House filters silently not applied on WoW 12.1.0 — Blizzard moved filter state from `AuctionHouseFrame.SearchBar.FilterButton.filters` into the `g_auctionHouseFilters` saved variable
+
+### Changed
+- Interface bumped to 120100 for WoW 12.1.0 compatibility
+
 ## [1.6.1] - 2026-06-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.7.0] - 2026-08-12
 
 ### Fixed
-- Auction House filters silently not applied on WoW 12.1.0 — Blizzard moved filter state from `AuctionHouseFrame.SearchBar.FilterButton.filters` into the `g_auctionHouseFilters` saved variable
+- Auction House filters stopped applying on WoW 12.1.0; Blizzard moved filter state from `AuctionHouseFrame.SearchBar.FilterButton.filters` into the `g_auctionHouseFilters` saved variable
 
 ### Changed
 - Interface bumped to 120100 for WoW 12.1.0 compatibility

--- a/DefaultCurrentExpansion.lua
+++ b/DefaultCurrentExpansion.lua
@@ -40,6 +40,12 @@ end
 local FILTER_CEO = Enum.AuctionHouseFilter and Enum.AuctionHouseFilter.CurrentExpansionOnly
 local FILTER_USABLE = Enum.AuctionHouseFilter and Enum.AuctionHouseFilter.UsableOnly
 
+-- 12.1.0 moved AH filter state out of the FilterButton and into this saved variable.
+-- Clear Filters replaces the whole table, so resolve it on every use — never cache.
+local function GetAuctionHouseFilters()
+	return g_auctionHouseFilters and g_auctionHouseFilters.filters
+end
+
 -- User's manual filter overrides for this AH session, keyed by filter enum (absent key = use addon setting)
 local userFilterOverride = {}
 -- What was last applied per filter, so the watcher can detect user changes
@@ -74,11 +80,11 @@ local function StartFilterWatcher()
 		end
 		local searchBar = AuctionHouseFrame.SearchBar
 		if not searchBar or not searchBar:IsShown() then return end
-		local filterButton = searchBar.FilterButton
-		if not filterButton or not filterButton.filters then return end
+		local filters = GetAuctionHouseFilters()
+		if not filters then return end
 
 		for _, filter in ipairs(watchedFilters) do
-			local currentState = filterButton.filters[filter] and true or false
+			local currentState = filters[filter] and true or false
 			if lastAppliedFilterState[filter] ~= nil and currentState ~= lastAppliedFilterState[filter] then
 				userFilterOverride[filter] = currentState
 			end
@@ -103,15 +109,15 @@ local function ApplyAuctionHouseFilter()
 	C_Timer.After(0.1, function()
 		if AuctionHouseFrame and AuctionHouseFrame:IsShown() then
 			local searchBar = AuctionHouseFrame.SearchBar
-			if searchBar and searchBar:IsShown() and searchBar.FilterButton then
-				local filterButton = searchBar.FilterButton
+			if searchBar and searchBar:IsShown() then
+				local filters = GetAuctionHouseFilters()
 
-				if filterButton.filters then
+				if filters then
 					if FILTER_CEO and DefaultCurrentExpansionDB.auctionHouse then
-						ApplyOneFilter(filterButton.filters, FILTER_CEO)
+						ApplyOneFilter(filters, FILTER_CEO)
 					end
 					if FILTER_USABLE and DefaultCurrentExpansionDB.usableOnlyAH then
-						ApplyOneFilter(filterButton.filters, FILTER_USABLE)
+						ApplyOneFilter(filters, FILTER_USABLE)
 					end
 
 					StartFilterWatcher()

--- a/DefaultCurrentExpansion.toc
+++ b/DefaultCurrentExpansion.toc
@@ -1,8 +1,8 @@
-## Interface: 120007
+## Interface: 120100
 ## Title: Default Current Expansion
 ## Notes: Automatically selects "Current Expansion Only" in Auction House and Crafting Orders filters
 ## Author: KidMoxie
-## Version: 1.6.1
+## Version: 1.7.0
 ## X-License: MIT
 ## X-Website: https://github.com/KidMoxie/default-current-expansion
 ## X-Curse-Project-ID: 1409180

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A World of Warcraft addon that automatically applies filters in the Auction Hous
 - Automatically applies "Current Expansion Only" filter when opening the Auction House and when browsing Crafting Orders
 - Optionally applies "Usable Only" filter for the Auction House and Crafting Orders
 - Each filter has independent per-surface (AH/CO) toggles
-- Compatible with retail WoW 12.0.5 (Midnight)
+- Compatible with retail WoW 12.1.0 (Midnight)
 
 ## Installation
 
@@ -59,7 +59,7 @@ After installation, simply:
 
 ## Compatibility
 
-- **Current Version:** Retail WoW 12.0.5 (Midnight)
+- **Current Version:** Retail WoW 12.1.0 (Midnight)
 - **Not compatible with:** Classic WoW, Classic Era, or Cataclysm Classic
 
 ## Contributing


### PR DESCRIPTION
12.1.0 moved Auction House filter state out of the frame and into a per-character saved variable. `FilterButton.filters` no longer exists, so the addon's nil guard skipped the apply block entirely and the AH filter was never set. No error, just silence. Crafting Orders was unaffected.

- Resolves the filters table through `g_auctionHouseFilters`, re-resolved per use since Clear Filters replaces it wholesale
- Bumps Interface to 120100 and version to 1.7.0
- Updates the two README compatibility lines, which had drifted to 12.0.5
- Documents the new path in AGENTS.md, plus a note on taint now surviving the whole session

Verified against the `12.1.0` tag of Gethe/wow-ui-source, which is byte-identical to `live`. Everything else the addon touches is unchanged: the filter enums, `SetDisplayMode`, both events, the Settings API, and the CO filter path. The wiki's 12.1.0 API changes page never mentioned this break, so it only turned up by diffing the tagged source.

Verified in-game.

## Follow-up PR

A Codex review caught a real problem this doesn't solve. Since `g_auctionHouseFilters` persists and is no longer reset when the AH opens, turning a toggle off leaves the previous `true` stranded. The filter keeps applying while the option reads as disabled, and it survives `/reload` and logout.

Pre-12.1.0 this came for free. Blizzard reset the table on every open, so the addon only ever had to add a `true` and stopping was enough to clean up. That assumption is gone, and I carried the write-only model over without noticing.

That fix goes in a separate PR, along with a changelog note that 12.1.0 now remembers AH filters per character between sessions. That one is a Blizzard change, but users will read it as ours. Both land before we tag 1.7.0.